### PR TITLE
Fix client options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,22 +22,19 @@ Or install it yourself as:
 $ gem install omniauth-okta
 ```
 
-### Environment Variables
-
-```bash
-OKTA_CLIENT_ID     # required
-OKTA_CLIENT_SECRET # required
-OKTA_ORG           # required - defaults to 'your-org' if unset
-OKTA_DOMAIN        # optional - defaults to 'okta.com' if unset
-```
-
 ### OmniAuth
 
 Here's an example for adding the middleware to a Rails app in `config/initializers/omniauth.rb`:
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :okta, ENV['OKTA_CLIENT_ID'], ENV['OKTA_CLIENT_SECRET']
+  provider :okta, ENV['OKTA_CLIENT_ID'], ENV['OKTA_CLIENT_SECRET'], {
+    client_options: {
+      site:          'https://your-org.okta.com',
+      authorize_url: 'https://your-org.okta.com/oauth2/v1/authorize',
+      token_url:     'https://your-org.okta.com/oauth2/v1/token'
+    }
+  }
 end
 ```
 
@@ -59,6 +56,11 @@ or add options like the following:
                   ENV['OKTA_CLIENT_SECRET'],
                   :scope => 'openid profile email',
                   :fields => ['profile', 'email'],
+                  :client_options => {
+                    :site =>          'https://your-org.okta.com',
+                    :authorize_url => 'https://your-org.okta.com/oauth2/v1/authorize',
+                    :token_url =>     'https://your-org.okta.com/oauth2/v1/token'
+                  }
                   :strategy_class => OmniAuth::Strategies::Okta)
 ```
 

--- a/lib/omniauth/strategies/okta.rb
+++ b/lib/omniauth/strategies/okta.rb
@@ -5,10 +5,6 @@ require 'omniauth-oauth2'
 module OmniAuth
   module Strategies
     class Okta < OmniAuth::Strategies::OAuth2
-
-      ORG           = ENV['OKTA_ORG']    || 'your-org'
-      DOMAIN        = ENV['OKTA_DOMAIN'] || 'okta'
-      BASE_URL      = "https://#{ORG}.#{DOMAIN}.com"
       DEFAULT_SCOPE = %[openid profile email].freeze
 
       option :name, 'okta'
@@ -17,9 +13,9 @@ module OmniAuth
       option :jwt_leeway, 60
 
       option :client_options, {
-        site:          BASE_URL,
-        authorize_url: "#{BASE_URL}/oauth2/v1/authorize",
-        token_url:     "#{BASE_URL}/oauth2/v1/token",
+        site:          'https://your-org.okta.com',
+        authorize_url: 'https://your-org.okta.com/oauth2/v1/authorize',
+        token_url:     'https://your-org.okta.com/oauth2/v1/token',
         response_type: 'id_token'
       }
 
@@ -79,9 +75,9 @@ module OmniAuth
                    nil,
                    false,
                    verify_iss:        true,
-                   iss:               BASE_URL,
+                   iss:               options[:client_options][:site],
                    verify_aud:        true,
-                   aud:               BASE_URL,
+                   aud:               options[:client_options][:site],
                    verify_sub:        true,
                    verify_expiration: true,
                    verify_not_before: true,


### PR DESCRIPTION
- Removed the environment variables for setting up the urls, the code that is configuring the gem can do that if they want to.
- Use the `options[:client_options][:site]` for `iis` and `aud` when validating the token instead of the environment variables
- Updated readme

If you need any other changes to be able to merge this let me know!