### PR TITLE
Make authorization server configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ or add options like the following:
                   fields: ['profile', 'email'],
                   client_options: {
                     site:          'https://your-org.okta.com',
-                    authorize_url: 'https://your-org.okta.com/oauth2/v1/authorize',
-                    token_url:     'https://your-org.okta.com/oauth2/v1/token'
+                    authorize_url: 'https://your-org.okta.com/oauth2/default/v1/authorize',
+                    token_url:     'https://your-org.okta.com/oauth2/default/v1/token',
+                    user_info_url: 'https://your-org.okta.com/oauth2/default/v1/userinfo',
                   },
                   strategy_class: OmniAuth::Strategies::Okta)
 ```

--- a/README.md
+++ b/README.md
@@ -30,9 +30,12 @@ Here's an example for adding the middleware to a Rails app in `config/initialize
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :okta, ENV['OKTA_CLIENT_ID'], ENV['OKTA_CLIENT_SECRET'], {
     client_options: {
-      site:           'https://your-org.okta.com',
-      authorize_url:  'https://your-org.okta.com/oauth2/v1/authorize',
-      token_url:      'https://your-org.okta.com/oauth2/v1/token'
+      site:                 'https://your-org.okta.com',
+      authorization_server: '<authorization_server>',
+      authorize_url:        'https://your-org.okta.com/oauth2/<authorization_server>/v1/authorize',
+      token_url:            'https://your-org.okta.com/oauth2/<authorization_server>/v1/token',
+      user_info_url:        'https://your-org.okta.com/oauth2/<authorization_server>/v1/userinfo',
+      audience:             'api://your-audience'
     }
   }
 end

--- a/lib/omniauth-okta/version.rb
+++ b/lib/omniauth-okta/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module Okta
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end

--- a/lib/omniauth/strategies/okta.rb
+++ b/lib/omniauth/strategies/okta.rb
@@ -13,10 +13,13 @@ module OmniAuth
 
       # These are defaults that need to be overriden on an implementation
       option :client_options, {
-        site:          'https://your-org.okta.com',
-        authorize_url: 'https://your-org.okta.com/oauth2/v1/authorize',
-        token_url:     'https://your-org.okta.com/oauth2/v1/token',
-        response_type: 'id_token'
+        site:                 'https://your-org.okta.com',
+        authorize_url:        'https://your-org.okta.com/oauth2/default/v1/authorize',
+        token_url:            'https://your-org.okta.com/oauth2/default/v1/token',
+        user_info_url:        'https://your-org.okta.com/oauth2/default/v1/userinfo',
+        response_type:        'id_token',
+        authorization_server: 'default',
+        audience:             'api://default'
       }
       option :scope, DEFAULT_SCOPE
 
@@ -46,6 +49,10 @@ module OmniAuth
         end
       end
 
+      def client_options
+        options.fetch(:client_options)
+      end
+
       alias :oauth2_access_token :access_token
 
       def access_token
@@ -59,7 +66,7 @@ module OmniAuth
       end
 
       def raw_info
-        @_raw_info ||= access_token.get('/oauth2/v1/userinfo').parsed || {}
+        @_raw_info ||= access_token.get(client_options.fetch(:user_info_url)).parsed || {}
       rescue ::Errno::ETIMEDOUT
         raise ::Timeout::Error
       end
@@ -68,14 +75,38 @@ module OmniAuth
         options[:redirect_uri] || (full_host + script_name + callback_path)
       end
 
+      # Returns the qualified URL for the authorization server
+      #
+      # This is necessary in the case where there is a custom authorization server.
+      #
+      # Okta provides a default, by default.
+      #
+      # @return [String]
+      def authorization_server_path
+        site                 = client_options.fetch(:site)
+        authorization_server = client_options.fetch(:authorization_server, 'default')
+
+        "#{site}/oauth2/#{authorization_server}"
+      end
+
+      # Specifies the audience for the authorization server
+      #
+      # By default, this is +'default'+. If using a custom authorization
+      # server, this will need to be set
+      #
+      # @return [String]
+      def authorization_server_audience
+        client_options.fetch(:audience, 'default')
+      end
+
       def validated_token(token)
         JWT.decode(token,
                    nil,
                    false,
                    verify_iss:        true,
-                   iss:               options[:client_options][:site],
                    verify_aud:        true,
-                   aud:               options[:client_options][:site],
+                   iss:               authorization_server_path,
+                   aud:               authorization_server_audience,
                    verify_sub:        true,
                    verify_expiration: true,
                    verify_not_before: true,

--- a/omniauth-okta.gemspec
+++ b/omniauth-okta.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "omniauth", "~> 1.0"
-  s.add_dependency "omniauth-oauth2", "~> 1.0"
+  s.add_dependency "omniauth", "~> 1.5"
+  s.add_dependency "omniauth-oauth2", ">= 1.4.0", "< 2.0"
 
   s.add_development_dependency "bundler", "~> 1.5"
   s.add_development_dependency "rake"

--- a/spec/omniauth/strategies/okta_spec.rb
+++ b/spec/omniauth/strategies/okta_spec.rb
@@ -21,12 +21,12 @@ describe OmniAuth::Strategies::Okta do
 
       it 'has default authorize url' do
         expect(subject.options.client_options.authorize_url).to \
-        eq("#{base_url}/oauth2/v1/authorize")
+        eq("#{base_url}/oauth2/default/v1/authorize")
       end
 
       it 'has default token url' do
         expect(subject.options.client_options.token_url).to \
-        eq("#{base_url}/oauth2/v1/token")
+        eq("#{base_url}/oauth2/default/v1/token")
       end
 
       it 'has default response_type' do


### PR DESCRIPTION
# Problem

I ran into the issue where I have multiple authorization servers in Okta and did not use the `default` authorization server.

`OmniAuth::Strategies::Okta` hard codes the `userinfo` endpoint to the `default` authorization server. Additionally, it tries to use the base URL authorization server to decode the JWT, as well as determine the audience (e.g. `http://my-okta-url/oauth2/v1` as opposed to `http://my-okta-url/oauth2/<custom or default>/v1`. The default audience is `api://default`.)

# Proposal

Add some configuration to allow us to support more than just the `default` authorization server, and also remove any kind of hard-coded endpoints.