### PR TITLE
Use OmniAuth 2.0.0

### DIFF
--- a/lib/omniauth-okta/version.rb
+++ b/lib/omniauth-okta/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module Okta
-    VERSION = '0.1.3'.freeze
+    VERSION = '1.0.0'.freeze
   end
 end

--- a/lib/omniauth/strategies/okta.rb
+++ b/lib/omniauth/strategies/okta.rb
@@ -72,7 +72,7 @@ module OmniAuth
       end
 
       def callback_url
-        options[:redirect_uri] || (full_host + script_name + callback_path)
+        options[:redirect_uri] || (full_host + callback_path)
       end
 
       # Returns the qualified URL for the authorization server

--- a/omniauth-okta.gemspec
+++ b/omniauth-okta.gemspec
@@ -14,10 +14,9 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "omniauth", "~> 1.5"
-  s.add_dependency "omniauth-oauth2", ">= 1.6.0", "< 2.0"
+  s.add_dependency "omniauth", "~> 2.0"
+  s.add_dependency "omniauth-oauth2", "~> 1.7", ">= 1.7.1"
 
-  s.add_development_dependency "bundler", "~> 1.5"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3"
   s.add_development_dependency "rack-test"

--- a/spec/omniauth/strategies/okta_spec.rb
+++ b/spec/omniauth/strategies/okta_spec.rb
@@ -3,10 +3,11 @@
 require 'spec_helper'
 
 describe OmniAuth::Strategies::Okta do
-
+  include OmniAuth::Test::StrategyTestCase
   subject { described_class.new({}) }
 
   let(:base_url) { 'https://your-org.okta.com' }
+  let(:strategy) { described_class }
 
   describe '#client' do
     it 'has default site' do
@@ -38,8 +39,9 @@ describe OmniAuth::Strategies::Okta do
 
   describe '#callback_path' do
     it 'has the correct callback path' do
-      expect(subject.callback_path).to \
-      eq('/auth/okta/callback')
+      post '/auth/okta'
+      expect(last_response.location).to \
+      eq('http://example.org/auth/okta/callback')
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,6 @@ require 'omniauth-okta'
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 
@@ -20,3 +19,6 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = 'random'
 end
+
+OmniAuth.config.test_mode = true
+OmniAuth.config.request_validation_phase = proc {}


### PR DESCRIPTION
OmniAuth 2.0.0 has been released

changed the callback_path test due to callback_path needing an instance of the strategy to properly evaluate now. 

[OmniAuth 2.0.0 release notes](https://github.com/omniauth/omniauth/releases/tag/v2.0.0)